### PR TITLE
Update team option selection dot color

### DIFF
--- a/css/components/what-if.css
+++ b/css/components/what-if.css
@@ -200,6 +200,7 @@
 
 .team-option input[type="radio"] {
     margin-right: 10px;
+    accent-color: var(--accent-dark);
 }
 
 .team-name {


### PR DESCRIPTION
Changed radio button accent-color from default blue to --accent-dark (dark brown #52472A) to better align with the warm color palette used in the selected team option styling (gold background, beige border).