### PR TITLE
Limit distribution height constraint

### DIFF
--- a/css/components/picks-matrix.css
+++ b/css/components/picks-matrix.css
@@ -251,6 +251,8 @@
 .distribution-list {
     display: grid;
     gap: 15px;
+    max-height: 600px;
+    overflow-y: auto;
 }
 
 .distribution-item {


### PR DESCRIPTION
Added max-height of 600px and overflow-y: auto to .distribution-list to prevent the distribution view from extending too far down the page. A scrollbar will now appear when there are many games.