### PR TITLE
Remove View Pantheon link, make holder cards clickable with sparkle

### DIFF
--- a/css/components/winners.css
+++ b/css/components/winners.css
@@ -31,12 +31,45 @@
     min-width: 200px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+/* Sparkle effect for holder cards */
+.holder-card::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: linear-gradient(
+        45deg,
+        transparent 30%,
+        rgba(255, 255, 255, 0.5) 50%,
+        transparent 70%
+    );
+    transform: translateX(-100%) translateY(-100%) rotate(45deg);
+    animation: none;
 }
 
 .holder-card:hover {
     transform: translateY(-2px);
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
     background: linear-gradient(135deg, rgba(255, 215, 0, 0.25), rgba(255, 255, 255, 0.95));
+}
+
+.holder-card:hover::before {
+    animation: holderSparkle 2s ease-in-out infinite;
+}
+
+@keyframes holderSparkle {
+    0% {
+        transform: translateX(-100%) translateY(-100%) rotate(45deg);
+    }
+    100% {
+        transform: translateX(100%) translateY(100%) rotate(45deg);
+    }
 }
 
 /* Trophy Icon */
@@ -49,6 +82,8 @@
     justify-content: center;
     font-size: 24px;
     flex-shrink: 0;
+    position: relative;
+    z-index: 1;
 }
 
 .holder-trophy-icon.goblet {
@@ -68,6 +103,8 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+    position: relative;
+    z-index: 1;
 }
 
 .holder-title {
@@ -82,67 +119,6 @@
     font-size: 16px;
     font-weight: 700;
     color: var(--text-primary);
-}
-
-/* Pantheon Link - Small button with sparkle on hover */
-.pantheon-link {
-    display: inline-flex;
-    align-items: center;
-    align-self: center;
-    gap: 5px;
-    padding: 5px 12px;
-    background: rgba(96, 125, 139, 0.15);
-    color: var(--mcc-blue-gray);
-    text-decoration: none;
-    border-radius: 4px;
-    font-size: 11px;
-    font-weight: 500;
-    transition: all 0.3s ease;
-    border: 1px solid rgba(96, 125, 139, 0.3);
-    position: relative;
-    overflow: hidden;
-}
-
-/* Sparkle effect - diagonal gradient shine on hover */
-.pantheon-link::before {
-    content: '';
-    position: absolute;
-    top: -50%;
-    left: -50%;
-    width: 200%;
-    height: 200%;
-    background: linear-gradient(
-        45deg,
-        transparent 30%,
-        rgba(255, 255, 255, 0.4) 50%,
-        transparent 70%
-    );
-    transform: translateX(-100%) translateY(-100%) rotate(45deg);
-    animation: none;
-}
-
-.pantheon-link:hover {
-    background: rgba(96, 125, 139, 0.25);
-    border-color: var(--mcc-blue-gray);
-    color: var(--mcc-dark-2);
-    box-shadow: 0 2px 8px rgba(96, 125, 139, 0.2);
-}
-
-.pantheon-link:hover::before {
-    animation: sparkle 2s ease-in-out infinite;
-}
-
-@keyframes sparkle {
-    0% {
-        transform: translateX(-100%) translateY(-100%) rotate(45deg);
-    }
-    100% {
-        transform: translateX(100%) translateY(100%) rotate(45deg);
-    }
-}
-
-.pantheon-link i {
-    font-size: 12px;
 }
 
 /* Pantheon Modal Specific Styles */
@@ -295,11 +271,6 @@
 
     .holder-name {
         font-size: 14px;
-    }
-
-    .pantheon-link {
-        padding: 8px 14px;
-        font-size: 12px;
     }
 
     .pantheon-modal-content {

--- a/js/components/Winners.js
+++ b/js/components/Winners.js
@@ -24,18 +24,6 @@ export function renderCurrentHolders() {
         container.appendChild(gobletCard);
     }
 
-    // Add Pantheon button in the middle
-    const pantheonBtn = document.createElement('a');
-    pantheonBtn.href = '#';
-    pantheonBtn.id = 'pantheonLink';
-    pantheonBtn.className = 'pantheon-link';
-    pantheonBtn.innerHTML = '<i class="fas fa-landmark"></i> View Pantheon';
-    pantheonBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-        showPantheonModal();
-    });
-    container.appendChild(pantheonBtn);
-
     // Create Funk-Eng Cup holder card
     if (winnersData.currentFunkEngHolder) {
         const funkEngCard = createHolderCard(
@@ -57,6 +45,7 @@ export function renderCurrentHolders() {
 function createHolderCard(title, holder, type) {
     const card = document.createElement('div');
     card.className = 'holder-card';
+    card.style.cursor = 'pointer';
     card.innerHTML = `
         <div class="holder-trophy-icon ${type}">
             <i class="fas fa-trophy"></i>
@@ -66,6 +55,12 @@ function createHolderCard(title, holder, type) {
             <div class="holder-name">${holder}</div>
         </div>
     `;
+
+    // Make card clickable to open Pantheon modal
+    card.addEventListener('click', () => {
+        showPantheonModal();
+    });
+
     return card;
 }
 


### PR DESCRIPTION
- Removed standalone View Pantheon link between holder cards
- Made holder cards clickable to open Pantheon modal directly
- Added cursor pointer to holder cards
- Added diagonal gradient sparkle effect to holder cards on hover
- Removed all pantheon-link CSS styles (no longer needed)
- Added z-index to holder content to ensure it appears above sparkle effect