### PR TITLE
Add tooltip to holder cards indicating they're clickable

### DIFF
--- a/js/components/Winners.js
+++ b/js/components/Winners.js
@@ -46,6 +46,7 @@ function createHolderCard(title, holder, type) {
     const card = document.createElement('div');
     card.className = 'holder-card';
     card.style.cursor = 'pointer';
+    card.title = 'Click to view historical winners';
     card.innerHTML = `
         <div class="holder-trophy-icon ${type}">
             <i class="fas fa-trophy"></i>


### PR DESCRIPTION
- Added title attribute "Click to view historical winners" to holder cards
- Tooltip appears on hover to guide users to click for Pantheon history